### PR TITLE
Upgrade protobuf dependency to 3.12.2

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,5 +1,5 @@
 object Versions {
-    const val protobuf = "3.9.0"
+    const val protobuf = "3.12.2"
     const val commonProto = "1.16.0"
     const val grpc = "1.23.0"
     const val kotlin = "1.3.61"


### PR DESCRIPTION
I need this version so I can use `PluginProtos.CodeGeneratorResponse.Builder.supportedFeatures` in my custom generator script. I verified this dependency doesn't break basic functionality, but since I cannot build whole project (something wrong with html java sources) I haven't checked everything still works. Though as far as I've been working with protobuf (since around 3.8 I believe) I haven't stepped over any backward compatibility issues.